### PR TITLE
Same width option for tvolnoti notifications

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -67,7 +67,8 @@ int main(int argc, const char* argv[]) {
             gopt_option('4', GOPT_ARG, gopt_shorts('4'), gopt_longs("high-icon")),
             gopt_option('s', GOPT_ARG, gopt_shorts('s'), gopt_longs("single-icon")),
             gopt_option('x', GOPT_ARG, gopt_shorts('x'), gopt_longs("bright-icon")),
-            gopt_option('v', GOPT_REPEAT, gopt_shorts('v'), gopt_longs("verbose"))));
+            gopt_option('v', GOPT_REPEAT, gopt_shorts('v'), gopt_longs("verbose")),
+            gopt_option('w', 0, gopt_shorts('w'), gopt_longs("same-width"))));
     const gchar* muteicon;
     const gchar* officon;
     const gchar* lowicon;
@@ -79,6 +80,7 @@ int main(int argc, const char* argv[]) {
     int debug = gopt(options, 'v');
     int muted = gopt(options, 'm');
     int nopr = gopt(options, 'n');
+    int same_width = gopt(options, 'w');
     int bright = gopt(options, 'b');
     int micon = gopt_arg(options, '0', &muteicon);
     int oicon = gopt_arg(options, '1', &officon);
@@ -163,7 +165,7 @@ int main(int argc, const char* argv[]) {
     print_debug_ok(debug);
 
     print_debug("Sending volume...", debug);
-    uk_ac_cam_db538_VolumeNotification_notify(proxy, volume, nobar, bright, muteicon, officon, lowicon, medicon, highicon, singleicon, brighticon, &error);
+    uk_ac_cam_db538_VolumeNotification_notify(proxy, volume, nobar, same_width, bright, muteicon, officon, lowicon, medicon, highicon, singleicon, brighticon, &error);
     if (error !=  NULL) {
         handle_error("Failed to send notification", error->message, FALSE);
         g_clear_error(&error);

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -73,7 +73,7 @@ GType volume_object_get_type(void);
 gboolean volume_object_notify(VolumeObject* obj,
                               gint value_in,
                               gint nobar_in,
-                              gint all_notifications_same_width_in,
+                              gint same_width_in,
                               gint brightness_in,
                               const gchar* muteicon_in,
                               const gchar* officon_in,
@@ -180,7 +180,7 @@ static gboolean time_handler(VolumeObject *obj)
 gboolean volume_object_notify(VolumeObject* obj,
                               gint value,
                               gint nobarvalue,
-                              gint all_notifications_same_width,
+                              gint same_width,
                               gint brightness,
                               const gchar* muteicon,
                               const gchar* officon,
@@ -278,8 +278,14 @@ gboolean volume_object_notify(VolumeObject* obj,
                                 obj->image_progressbar, width_full, 0);
                 set_progressbar_image(GTK_WINDOW(obj->notification), obj->image_progressbar);
                 print_debug_ok(obj->debug);
-        } else if (all_notifications_same_width) {
-                gint width_full = obj->width_progressbar;
+        } else if (same_width == 1) {
+                g_clear_object(&obj->image_progressbar);
+                obj->image_progressbar = gdk_pixbuf_new(GDK_COLORSPACE_RGB,
+                                                        TRUE,
+                                                        gdk_pixbuf_get_bits_per_sample(obj->image_progressbar_empty),
+                                                        obj->width_progressbar,
+                                                        obj->height_progressbar);
+
                 set_progressbar_image(GTK_WINDOW(obj->notification), obj->image_progressbar);
         }
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -73,6 +73,7 @@ GType volume_object_get_type(void);
 gboolean volume_object_notify(VolumeObject* obj,
                               gint value_in,
                               gint nobar_in,
+                              gint all_notifications_same_width_in,
                               gint brightness_in,
                               const gchar* muteicon_in,
                               const gchar* officon_in,
@@ -179,6 +180,7 @@ static gboolean time_handler(VolumeObject *obj)
 gboolean volume_object_notify(VolumeObject* obj,
                               gint value,
                               gint nobarvalue,
+                              gint all_notifications_same_width,
                               gint brightness,
                               const gchar* muteicon,
                               const gchar* officon,
@@ -276,6 +278,9 @@ gboolean volume_object_notify(VolumeObject* obj,
                                 obj->image_progressbar, width_full, 0);
                 set_progressbar_image(GTK_WINDOW(obj->notification), obj->image_progressbar);
                 print_debug_ok(obj->debug);
+        } else if (all_notifications_same_width) {
+                gint width_full = obj->width_progressbar;
+                set_progressbar_image(GTK_WINDOW(obj->notification), obj->image_progressbar);
         }
 
         obj->time_left = obj->timeout;

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -201,7 +201,8 @@ gboolean volume_object_notify(VolumeObject* obj,
         }
 
         obj->brightness = brightness;
-
+        obj->settings.same_width = same_width;
+        obj->settings.nobar = nobarvalue;
 
         if (obj->notification == NULL) {
                 print_debug("Creating new notification...", obj->debug);

--- a/src/notification.c
+++ b/src/notification.c
@@ -63,6 +63,8 @@ Settings get_default_settings() {
     settings.pos_x = -1;
     settings.pos_y = -1;
     settings.center = 0;
+    settings.same_width = 0;
+    settings.nobar =  0;
     return settings;
 }
 
@@ -516,6 +518,8 @@ GtkWindow* create_notification(Settings settings) {
 
     if(settings.horizontal) {
         gtk_alignment_set_padding (GTK_ALIGNMENT (windata->iconbox), 0, 0, 0, 0);
+    } else if(settings.nobar && settings.same_width) {
+        gtk_alignment_set_padding (GTK_ALIGNMENT (windata->iconbox), IMAGE_PADDING/2, IMAGE_PADDING/2, 0, 0);
     } else {
         gtk_alignment_set_padding (GTK_ALIGNMENT (windata->iconbox), 0, IMAGE_PADDING, 0, 0);
     }

--- a/src/notification.h
+++ b/src/notification.h
@@ -35,6 +35,8 @@ typedef struct {
     gint pos_y;
     gint horizontal;
     gboolean center;
+    gboolean same_width;
+    gint nobar;
 } Settings;
 
 Settings get_default_settings();

--- a/src/specs.xml
+++ b/src/specs.xml
@@ -5,6 +5,7 @@
     <method name="notify">
       <arg type="i" name="volume" direction="in" />
       <arg type="i" name="nobar" direction="in" />
+      <arg type="i" name="same_width" direction="in" />
       <arg type="i" name="bright" direction="in" />
       <arg type="s" name="muteicon" direction="in" />
       <arg type="s" name="officon" direction="in" />


### PR DESCRIPTION
Added -w flag in tvolnoti-show (to be discussed, how to name it properly), 
Notification with progress bar:
![image](https://user-images.githubusercontent.com/32205463/223225428-6a38f779-4575-43ff-9481-abd7bea10cb6.png)
Notification without progress bar(old):
![image](https://user-images.githubusercontent.com/32205463/223225505-0a44f586-40af-47e0-a991-bde62006c916.png)
Notification with same-width flag on:
![image](https://user-images.githubusercontent.com/32205463/223226604-4ea506f0-ab3c-4f6f-b4af-d2a3e58a706a.png)
